### PR TITLE
Fixed the path used to include toyboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ toybox update
 Then, if your code is in the `source` folder, just import the following:
 
 ```lua
-import '../toyboxes/sequence.lua'
+import '../toyboxes/toyboxes.lua'
 ```
 
 #### Manually


### PR DESCRIPTION
toybox.py generates a single lua file that makes it easy to import all the toyboxes required automatically. It doesn't generate individual files in the toyboxes folder.

Also tagged this as the first version so that versioning can be used.