### PR TITLE
Fix sequence:again()

### DIFF
--- a/sequence.lua
+++ b/sequence.lua
@@ -160,7 +160,7 @@ function sequence:again( repeatCount, mirror )
 
 	local previousEasing = self.easings[self.easingCount]
 
-	for i = 1, number do
+	for i = 1, repeatCount do
 		local newEasing = self:newEasing()
 
 		-- setup first empty easing at the beginning of the sequence


### PR DESCRIPTION
- wrong variable name used in for loop

Fixes #6 