### PR TITLE
Safely removing running sequences

### DIFF
--- a/sequence.lua
+++ b/sequence.lua
@@ -59,10 +59,10 @@ function sequence.update( pacing )
 		local seq = _runningSequences[index]
 
 		if seq.isRunning == true then
-			seq:updateCallbacks( deltaTime )
-
 			seq.time = seq.time + deltaTime
 			seq.cachedResultTimestamp = nil
+			
+			seq:updateCallbacks( deltaTime )
 
 			if seq:isDone() then
 				seq.isRunning = false
@@ -333,6 +333,8 @@ function sequence:updateCallbacks( dt )
 		return
 	end
 
+	local previousTime = self.time - dt
+	
 	local callTimeRange = function( clampedStart, clampedEnd)
 		if clampedStart>clampedEnd then
 			clampedStart, clampedEnd = clampedEnd, clampedStart
@@ -349,7 +351,7 @@ function sequence:updateCallbacks( dt )
 
 	-- most straightforward case: no loop
 	if not self.loopType then
-		local clampedTime = self:getClampedTime( self.time )
+		local clampedTime = self:getClampedTime( previousTime )
 		callTimeRange(clampedTime, clampedTime+dt)
 		return
 	end
@@ -362,7 +364,7 @@ function sequence:updateCallbacks( dt )
 		callTimeRange(0, self.duration)
 	end
 
-	local clampedTime, isForward = self:getClampedTime( self.time )
+	local clampedTime, isForward = self:getClampedTime( previousTime )
 	local endTime = clampedTime
 	if isForward then
 		endTime = endTime + dt

--- a/sequence.lua
+++ b/sequence.lua
@@ -349,10 +349,11 @@ function sequence:updateCallbacks( dt )
 		end
 
 		for index, cbObject in pairs(self.callbacks) do
-			if cbObject.timestamp>=clampedStart and cbObject.timestamp<=clampedEnd then
-				if type(cbObject.fn)=="function" then
-					cbObject.fn()
-				end
+			if cbObject.timestamp==clampedStart and clampedStart==0 or
+			   	cbObject.timestamp>clampedStart and cbObject.timestamp<=clampedEnd then
+					if type(cbObject.fn)=="function" then
+						cbObject.fn()
+					end
 			end
 		end
 	end

--- a/sequence.lua
+++ b/sequence.lua
@@ -58,14 +58,19 @@ function sequence.update( pacing )
 	for index = #_runningSequences, 1, -1 do
 		local seq = _runningSequences[index]
 
-		seq:updateCallbacks( deltaTime )
+		if seq.isRunning == true then
+			seq:updateCallbacks( deltaTime )
 
-		seq.time = seq.time + deltaTime
-		seq.cachedResultTimestamp = nil
+			seq.time = seq.time + deltaTime
+			seq.cachedResultTimestamp = nil
 
-		if seq:isDone() then
+			if seq:isDone() then
+				seq.isRunning = false
+			end
+		end
+
+		if seq.isRunning == false then
 			table.remove(_runningSequences, index)
-			seq.isRunning = false
 		end
 	end
 end
@@ -415,10 +420,6 @@ function sequence:addRunning()
 end
 
 function sequence:removeRunning()
-	local indexInRunningTable = table.indexOfElement(_runningSequences, self)
-	if indexInRunningTable then
-		table.remove(_runningSequences, indexInRunningTable)
-	end
 	self.isRunning = false
 end
 

--- a/sequence.lua
+++ b/sequence.lua
@@ -52,7 +52,7 @@ function sequence.update( pacing )
 	pacing = pacing or 1
 
 	local currentTime = playdate.getCurrentTimeMilliseconds()
-	local deltaTime = ((currentTime-_previousUpdateTime) / 1000) * pacing
+	local deltaTime = (currentTime-_previousUpdateTime) * pacing
 	_previousUpdateTime = currentTime
 
 	for index = #_runningSequences, 1, -1 do
@@ -126,6 +126,7 @@ function sequence:to( to, duration, easingFunction, ... )
 	-- default parameters
 	to = to or 0
 	duration = duration or 0.3
+	duration = math.floor(1000*duration)
 	easingFunction = easingFunction or _easings.inOutQuad
 	if type(easingFunction)=="string" then
 		easingFunction = _easings[easingFunction] or _easings.inOutQuad
@@ -203,6 +204,7 @@ function sequence:sleep( duration )
 	if not self then return end
 
 	duration = duration or 0.5
+	duration = math.floor(1000*duration)
 	if duration==0 then
 		return self
 	end
@@ -227,6 +229,7 @@ function sequence:callback( fn, timeOffset )
 	if not self then return end
 
 	timeOffset = timeOffset or 0
+	timeOffset = math.floor(1000*timeOffset)
 
 	local lastEasing = self.easings[self.easingCount]
 
@@ -317,7 +320,11 @@ function sequence:get( time )
 		return 0
 	end
 
-	time = time or self.time
+	if time == nil then
+		time = self.time
+	else
+		time = math.floor(1000*time)
+	end
 
 	-- try to get cached result
 	if self.cachedResultTimestamp==time then

--- a/sequence.lua
+++ b/sequence.lua
@@ -76,9 +76,17 @@ function sequence.update( pacing )
 end
 
 function sequence.print()
-	print("Sequences running:", #_runningSequences)
+	local count = 0
 	for index, seq in pairs(_runningSequences) do
-		print(" Sequence", index, seq)
+		if seq.isRunning then
+			count = count + 1
+		end
+	end
+	print("Sequences running:", count)
+	for index, seq in pairs(_runningSequences) do
+		if seq.isRunning then
+			print(" Sequence", index, seq)
+		end
 	end
 end
 


### PR DESCRIPTION
Fixed some cases where one sequence in callback stops another sequence. Previously, this could modify table _runningSequences in a loop of Sequence.update().