### PR TITLE
Сorrect behavior when adding zero time periods

### DIFF
--- a/sequence.lua
+++ b/sequence.lua
@@ -278,16 +278,27 @@ function sequence:getEasingByTime( clampedTime )
 	end
 
 	local easingIndex = self.previousUpdateEasingIndex or 1
+	local foundEasing = false
 
 	while easingIndex>=1 and easingIndex<=self.easingCount do
 		local easing = self.easings[easingIndex]
 
 		if clampedTime < easing.timestamp then
 			easingIndex = easingIndex - 1
-		elseif clampedTime == (easing.timestamp+easing.duration) and easingIndex < self.easingCount or
-			clampedTime > (easing.timestamp+easing.duration) then
+		elseif clampedTime > (easing.timestamp+easing.duration) then
+			easingIndex = easingIndex + 1
+		elseif clampedTime == (easing.timestamp+easing.duration) then
+			-- if the time is in between two easings, we prioritize the highest index (if it exists)
+			if self.easings[easingIndex + 1] then
 				easingIndex = easingIndex + 1
+			else
+				foundEasing = true
+			end
 		else
+			foundEasing = true
+		end
+
+		if foundEasing then
 			self.previousUpdateEasingIndex = easingIndex
 			return easing, easingIndex
 		end

--- a/sequence.lua
+++ b/sequence.lua
@@ -284,8 +284,9 @@ function sequence:getEasingByTime( clampedTime )
 
 		if clampedTime < easing.timestamp then
 			easingIndex = easingIndex - 1
-		elseif clampedTime > (easing.timestamp+easing.duration) then
-			easingIndex = easingIndex + 1
+		elseif clampedTime == (easing.timestamp+easing.duration) and easingIndex < self.easingCount or
+			clampedTime > (easing.timestamp+easing.duration) then
+				easingIndex = easingIndex + 1
 		else
 			self.previousUpdateEasingIndex = easingIndex
 			return easing, easingIndex
@@ -314,7 +315,12 @@ function sequence:get( time )
 	-- we calculate and cache the result
 	local clampedTime = self:getClampedTime(time)
 	local easing = self:getEasingByTime(clampedTime)
-	local result = easing.fn(clampedTime-easing.timestamp, easing.from, easing.to-easing.from, easing.duration, table.unpack(easing.params or {}))
+	local result
+	if easing.duration == 0 then
+		result = easing.to
+	else
+		result = easing.fn(clampedTime-easing.timestamp, easing.from, easing.to-easing.from, easing.duration, table.unpack(easing.params or {}))
+	end
 
 	-- cache
 	self.cachedResultTimestamp = clampedTime


### PR DESCRIPTION
Correct behaviour for this case:

local sequence = sequence.new():from(10):to(20, 1):to(10, 0)
print(sequence:get(1))
-- Expected: 10.0 (before PR we got 20.0)